### PR TITLE
Add Flask script mode

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -144,6 +144,7 @@
         <select id="script-mode">
             <option value="html-js-css">HTML, JS, CSS</option>
             <option value="html-only">HTML Only</option>
+            <option value="flask">Flask</option>
         </select>
     <div class="image-option-select">
         <label for="edit-image-option">Image Option for Edit:</label>
@@ -309,7 +310,7 @@
 
         function loadGeneratedScripts() {
             const scriptMode = document.getElementById('script-mode').value;
-            if (scriptMode === 'html-js-css') {
+            if (scriptMode === 'html-js-css' || scriptMode === 'flask') {
                 fetch('/generated/script.js')
                     .then(response => response.text())
                     .then(scriptContent => {


### PR DESCRIPTION
## Summary
- introduce `flask` as a new script mode
- instruct AI to generate Flask apps with templates/static folders
- adjust client dropdown and script loader
- manage assets and directories for Flask
- update code generation and editing logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685fe25297788331a405603ed5edabff