### PR TITLE
Add pygame script mode and directory creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # gamecore
 an AI game creator
+
+## New Features
+
+- Automatically creates required directories (`generated`, `generated/uploads`, and `old-generated`) if they do not exist.
+- Added **Pygame** option to the script mode selector. When selected, the AI produces a single `game.py` file using the pygame library.

--- a/public/index.html
+++ b/public/index.html
@@ -145,6 +145,7 @@
             <option value="html-js-css">HTML, JS, CSS</option>
             <option value="html-only">HTML Only</option>
             <option value="flask">Flask</option>
+            <option value="pygame">Pygame</option>
         </select>
     <div class="image-option-select">
         <label for="edit-image-option">Image Option for Edit:</label>


### PR DESCRIPTION
## Summary
- create generated folders on startup
- handle missing upload directories
- add pygame script mode with prompts and saving to `game.py`
- update HTML select dropdown for pygame
- document new pygame mode

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6860a54b344483318c5d6af838563910