### PR TITLE
Hide HTML options when using pygame

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -141,7 +141,7 @@
     </div>
     <div class="script-mode-select">
         <label for="script-mode">Select Script Mode:</label>
-        <select id="script-mode">
+        <select id="script-mode" onchange="toggleScriptMode()">
             <option value="html-js-css">HTML, JS, CSS</option>
             <option value="html-only">HTML Only</option>
             <option value="flask">Flask</option>
@@ -155,7 +155,7 @@
             <option value="exclude">Exclude Images</option>
         </select>
     </div>
-    <div class="html-file-option-select">
+    <div class="html-file-option-select" id="html-file-option-container">
         <label for="html-file-option">HTML File Option:</label>
         <select id="html-file-option" onchange="toggleHtmlCount('html-file-option','html-file-count')">
             <option value="single">Single HTML</option>
@@ -164,7 +164,7 @@
         </select>
         <input type="number" id="html-file-count" min="2" value="2" style="display:none;" placeholder="Number of pages">
     </div>
-    <div class="html-file-option-select">
+    <div class="html-file-option-select" id="edit-html-file-option-container">
         <label for="edit-html-file-option">HTML File Option for Edit:</label>
         <select id="edit-html-file-option" onchange="toggleHtmlCount('edit-html-file-option','edit-html-file-count')">
             <option value="single">Single HTML</option>
@@ -193,6 +193,19 @@
                 input.style.display = 'inline-block';
             } else {
                 input.style.display = 'none';
+            }
+        }
+
+        function toggleScriptMode() {
+            const mode = document.getElementById('script-mode').value;
+            const htmlOption = document.getElementById('html-file-option-container');
+            const editHtmlOption = document.getElementById('edit-html-file-option-container');
+            if (mode === 'pygame') {
+                htmlOption.style.display = 'none';
+                editHtmlOption.style.display = 'none';
+            } else {
+                htmlOption.style.display = 'block';
+                editHtmlOption.style.display = 'block';
             }
         }
 
@@ -561,6 +574,7 @@ async function continueCodeGeneration() {
             }
         });
         loadGeneratedScripts();
+        toggleScriptMode();
         toggleHtmlCount('html-file-option','html-file-count');
         toggleHtmlCount('edit-html-file-option','edit-html-file-count');
     </script>

--- a/server.js
+++ b/server.js
@@ -1197,10 +1197,12 @@ if (imageOption === 'include') {
     basePrompt += ` Use image placeholder [IMAGE:description] where images should be placed ONLY if images are needed. If you're adding new images, do not put image placeholders over where images are already refrenced in the code. for example, if you're trying to modify a html code to add more images for new items on the menu, but some images already exist and are refrenced on the menu html code, such as image_html1_1.png or image_html_1.png, then leave those alone AND DONT MODIFY THEM IN ANY WAY but add image placeholder for the new items. DO NOT PUT PLACEHOLDERS OVER PRE-EXISTING REFRENCED IMAGE AND DO NOT USE ANY OTHER PLACEHOLDER AND DO NOT REFRENCE OTHER IMAGES, ONLY USE [IMAGE:description] AND ONLY IF NECESSARY`;
 }
 
-if (htmlFileOption === 'multiple') {
-    basePrompt += ` Ensure that you maintain or create links between the HTML files as needed. You can create up to ${htmlPageCount} HTML files in total.`;
-} else if (htmlFileOption === 'multiple-ai') {
-    basePrompt += ` Ensure that you maintain or create links between the HTML files as needed. Generate as many HTML files as necessary.`;
+if (scriptMode !== 'pygame') {
+    if (htmlFileOption === 'multiple') {
+        basePrompt += ` Ensure that you maintain or create links between the HTML files as needed. You can create up to ${htmlPageCount} HTML files in total.`;
+    } else if (htmlFileOption === 'multiple-ai') {
+        basePrompt += ` Ensure that you maintain or create links between the HTML files as needed. Generate as many HTML files as necessary.`;
+    }
 }
 
     if (uploadedFiles.length > 0) {
@@ -1233,7 +1235,7 @@ if (htmlFileOption === 'multiple') {
     }
 
     basePrompt += `. Make sure to wrap each code section in appropriate markdown code blocks (e.g., \`\`\`html, \`\`\`css, \`\`\`javascript). `
-    if(htmlFileOption !== 'single'){
+    if(scriptMode !== 'pygame' && htmlFileOption !== 'single'){
         basePrompt += `For HTML files, include the filename as a comment at the start of the code block, like this:
 \`\`\`html
 // index.html


### PR DESCRIPTION
## Summary
- hide HTML file option selectors when Pygame mode is chosen
- ensure prompts omit HTML instructions for Pygame

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_6860ab4dbea883318eb22bd7043a88a6