### PR TITLE
Add PyQt5 script mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ an AI game creator
 
 - Automatically creates required directories (`generated`, `generated/uploads`, and `old-generated`) if they do not exist.
 - Added **Pygame** option to the script mode selector. When selected, the AI produces a single `game.py` file using the pygame library.
+- Added **PyQt5** option to the script mode selector. When selected, the AI generates a single `app.py` file using the PyQt5 framework.

--- a/public/index.html
+++ b/public/index.html
@@ -146,6 +146,7 @@
             <option value="html-only">HTML Only</option>
             <option value="flask">Flask</option>
             <option value="pygame">Pygame</option>
+            <option value="pyqt5">PyQt5</option>
         </select>
     <div class="image-option-select">
         <label for="edit-image-option">Image Option for Edit:</label>
@@ -200,7 +201,7 @@
             const mode = document.getElementById('script-mode').value;
             const htmlOption = document.getElementById('html-file-option-container');
             const editHtmlOption = document.getElementById('edit-html-file-option-container');
-            if (mode === 'pygame') {
+            if (mode === 'pygame' || mode === 'pyqt5') {
                 htmlOption.style.display = 'none';
                 editHtmlOption.style.display = 'none';
             } else {


### PR DESCRIPTION
## Summary
- support PyQt5 script generation in API and UI
- hide HTML options when PyQt5 is selected
- save PyQt5 code to `app.py`
- document new script mode

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6860adb803208331af8ca47d34010466