### PR TITLE
Implement patch-based edit system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "setprototypeof": "^1.2.0",
         "side-channel": "^1.0.6",
         "statuses": "^2.0.1",
+        "string-similarity": "^4.0.4",
         "toidentifier": "^1.0.1",
         "tr46": "^0.0.3",
         "type-is": "^1.6.18",
@@ -1661,6 +1662,13 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/string-similarity": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
+      "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "ISC"
     },
     "node_modules/strip-json-comments": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "setprototypeof": "^1.2.0",
     "side-channel": "^1.0.6",
     "statuses": "^2.0.1",
+    "string-similarity": "^4.0.4",
     "toidentifier": "^1.0.1",
     "tr46": "^0.0.3",
     "type-is": "^1.6.18",


### PR DESCRIPTION
## Summary
- overhaul edit system to use patch-style updates
- add conversation history management
- support complex fallback when applying code edits
- track entire project layout for edit prompts
- include new dependency `string-similarity`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866088db52c8331a080f1b9f8f236dc