### PR TITLE
Improve snippet indentation handling

### DIFF
--- a/helpers/reindent.js
+++ b/helpers/reindent.js
@@ -1,0 +1,18 @@
+const dedent = str => {
+  const lines = str.replace(/\r\n/g, '\n').split('\n');
+  const indentLens = lines
+    .filter(l => l.trim())
+    .map(l => l.match(/^\s*/)[0].length);
+  const minIndent = Math.min(...indentLens, 0);
+  return lines.map(l => l.slice(minIndent)).join('\n');
+};
+
+function reindentSnippet(snippet, anchorIndent) {
+  const indentStr = anchorIndent;
+  const rawLines  = dedent(snippet).split('\n');
+  return rawLines
+    .map(l => (l.trim() ? indentStr + l : l))
+    .join('\n');
+}
+
+module.exports = { reindentSnippet };

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const { JSDOM } = require('jsdom');
 const jshint = require('jshint');
 const csslint = require('csslint').CSSLint;
 const stringSimilarity = require('string-similarity');
+const { reindentSnippet } = require("./helpers/reindent");
 require('dotenv').config();
 
 //to do: html selection option
@@ -933,10 +934,8 @@ function applyEditsToFiles(edits) {
                 const oldFirstLine = edit.old.split('\n')[0];
                 const match = content.match(new RegExp(oldFirstLine.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
                 const indent = match ? (match[0].match(/^\s*/)[0] || '') : '';
-                const newLines = edit.new.split('\n');
-                const baseIndent = newLines[0].match(/^\s*/)[0] || '';
-                const adjusted = newLines.map(l => indent + l.replace(new RegExp('^' + baseIndent), ''));
-                content = replaceWithFallback(content, edit.old, adjusted.join('\n'));
+                const adjusted = reindentSnippet(edit.new, indent);
+                content = replaceWithFallback(content, edit.old, adjusted);
                 modified.add(f.path);
                 edit.applied = true;
             }


### PR DESCRIPTION
## Summary
- add helper to reindent inserted code blocks
- use helper in `applyEditsToFiles`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686660f382848331b932cac2dfa1c222